### PR TITLE
fix bunchCrossing return type

### DIFF
--- a/VertexCompositeAnalyzer/plugins/ParticleAnalyzer.cc
+++ b/VertexCompositeAnalyzer/plugins/ParticleAnalyzer.cc
@@ -758,7 +758,7 @@ ParticleAnalyzer::fillEventInfo(const edm::Event& iEvent)
   eventInfo_.add("RunNb", iEvent.id().run());
   eventInfo_.add("EventNb", getUInt(iEvent.id().event()));
   eventInfo_.add("LSNb", getUShort(iEvent.luminosityBlock()));
-  eventInfo_.add("BXNb", getUShort(iEvent.bunchCrossing()));
+  eventInfo_.add("BXNb", getShort(iEvent.bunchCrossing()));
 
   // fill vertex information
   eventInfo_.add("nPV", getUChar(vertices_.size()));


### PR DESCRIPTION
[edm::EventBase.bunchCrossing](http://cmsdoxygen.web.cern.ch/cmsdoxygen/CMSSW_10_3_3_patch1/doc/html/d9/df8/classedm_1_1EventBase.html#ae8c70c5be75bbbd4f52b5220e60a9c4e) return int instead of uint