### PR TITLE
update dedx configs and fix bugs of two-layer decay

### DIFF
--- a/VertexCompositeAnalyzer/plugins/ParticleAnalyzer.cc
+++ b/VertexCompositeAnalyzer/plugins/ParticleAnalyzer.cc
@@ -190,7 +190,7 @@ private:
   TTree* tree_ = 0;
   TTree* ntuple_ = 0;
 
-  bool isMC_;
+  bool isMC_, vtxSortByTrkSize_;
   reco::Vertex vertex_;
   reco::Particle::Point genVertex_;
   reco::VertexCollection vertices_;
@@ -771,8 +771,10 @@ ParticleAnalyzer::getEventData(const edm::Event& iEvent, const edm::EventSetup& 
       vertices_.push_back(pv);
     }
   }
-  auto byTracksSize = [] (const reco::Vertex& v1, const reco::Vertex& v2) -> bool { return v1.tracksSize() > v2.tracksSize(); };
-  std::sort(vertices_.begin(), vertices_.end(), byTracksSize);
+  if (vtxSortByTrkSize_) {
+    auto byTracksSize = [] (const reco::Vertex& v1, const reco::Vertex& v2) -> bool { return v1.tracksSize() > v2.tracksSize(); };
+    std::sort(vertices_.begin(), vertices_.end(), byTracksSize);
+  }
   if (vertices_.empty())
   {
     edm::Handle<reco::BeamSpot> beamspot;
@@ -2314,6 +2316,13 @@ void
 ParticleAnalyzer::loadConfiguration(const edm::ParameterSet& config, const edm::Run& iRun)
 {
   if (config.empty()) return;
+
+  if (config.existsAs<bool>("vtxSortByTrkSize"))
+  {
+    vtxSortByTrkSize_ = config.getParameter<bool>("vtxSortByTrkSize");
+  } else {
+    vtxSortByTrkSize_ = true;
+  }
 
   HepPDT::ParticleID pid;
   if (config.existsAs<int>("pdgId"))

--- a/VertexCompositeAnalyzer/plugins/ParticleAnalyzer.cc
+++ b/VertexCompositeAnalyzer/plugins/ParticleAnalyzer.cc
@@ -180,6 +180,7 @@ private:
   const std::vector<UInt_t> genPdgIdV_;
   std::map<std::string, bool> addInfo_;
   std::set<int> sourceId_, genPdgId_;
+  std::vector<std::string> dedxInfo_;
 
   HLTPrescaleProvider hltPrescaleProvider_;
   std::vector<std::vector<int> > l1PrescaleTable_;
@@ -1379,7 +1380,7 @@ ParticleAnalyzer::fillRecoParticleInfo(const pat::GenericParticle& cand, const U
   // generated particle information
   if (isMC_)
   {
-    if (!cand.hasUserInt("isGenMatched")) { addGenParticle(*const_cast<pat::GenericParticle*>(&cand), cand.p4(), genParticlesToMatch_); } 
+    if (!cand.hasUserInt("isGenMatched")) { addGenParticle(*const_cast<pat::GenericParticle*>(&cand), cand.p4(), genParticlesToMatch_); }
     const auto& genPar = cand.genParticleRef();
     info.add("genIdx", fillGenParticleInfo(genPar, idx));
     info.add("matchGEN", genPar.isNonnull());
@@ -1559,7 +1560,12 @@ ParticleAnalyzer::fillTrackInfo(const pat::GenericParticle& cand, const UShort_t
   info.add("xyDCASignificance", getFloat(cand, "dxySig"));
 
   // dEdx information
-  if (addInfo_.at("dEdx")) info.add("dEdxHarmonic2", getFloat(cand, "dEdx"));
+  if (addInfo_.at("dEdxs")) {
+    for (const auto input : dedxInfo_) {
+      std::string dedxName = "dEdx_" + input;
+      info.add(dedxName, getFloat(cand, dedxName));
+    }
+  }
 
   // push data and return index
   info.pushData(cand);
@@ -2328,9 +2334,10 @@ ParticleAnalyzer::loadConfiguration(const edm::ParameterSet& config, const edm::
     addInfo_["track"] = pid.threeCharge()!=0;
   }
 
-  if (!addInfo_["dEdx"] && config.existsAs<edm::InputTag>("dedxHarmonic2"))
+  if (!addInfo_["dEdxs"] && config.existsAs<std::vector<std::string>>("dEdxInputs"))
   {
-    addInfo_["dEdx"] = config.getParameter<edm::InputTag>("dedxHarmonic2").label()!="";
+    dedxInfo_ = config.getParameter<std::vector<std::string> >("dEdxInputs");
+    addInfo_["dEdxs"] = dedxInfo_.size();
   }
 
   if (!addInfo_["mva"] && config.existsAs<edm::InputTag>("mva"))

--- a/VertexCompositeProducer/interface/ParticleFitter.h
+++ b/VertexCompositeProducer/interface/ParticleFitter.h
@@ -231,7 +231,7 @@ class ParticleFitter {
 
  private:
   int pdgId_;
-  bool doSwap_, matchVertex_;
+  bool doSwap_, matchVertex_, vtxSortByTrkSize_;
   double mass_, width_;
   std::vector<UInt_t> fitAlgoV_;
   std::vector<double> puMap_;

--- a/VertexCompositeProducer/interface/ParticleFitter.h
+++ b/VertexCompositeProducer/interface/ParticleFitter.h
@@ -164,7 +164,7 @@ class ParticleDaughter {
   void addData(pat::GenericParticle& c, const pat::MuonRef& p, const bool& embedInfo);
   void addData(pat::GenericParticle& c, const pat::ElectronRef& p, const bool& embedInfo);
   void setMVA (pat::GenericParticle& c, const size_t& i, const edm::Handle<std::vector<float> >& m);
-  void setDeDx(pat::GenericParticle& c, const edm::Handle<edm::ValueMap<reco::DeDxData> >& m);
+  void setDeDx(pat::GenericParticle& c, const std::map<std::string, edm::Handle<edm::ValueMap<reco::DeDxData> > >& m);
   void addMuonL1Info(pat::GenericParticle& c, const edm::Handle<pat::TriggerObjectStandAloneMatch>& m);
 
   int pdgId_;
@@ -179,8 +179,9 @@ class ParticleDaughter {
 
   edm::EDGetTokenT<pat::GenericParticleCollection> token_source_;
   edm::EDGetTokenT<std::vector<float> >            token_mva_;
-  edm::EDGetTokenT<edm::ValueMap<reco::DeDxData> > token_dedx_;
   edm::EDGetTokenT<pat::TriggerObjectStandAloneMatch> token_muonL1Info_;
+
+  std::map<std::string, edm::EDGetTokenT<edm::ValueMap<reco::DeDxData> > > tokens_dedx_;
 };
 
 

--- a/VertexCompositeProducer/plugins/BuildFile.xml
+++ b/VertexCompositeProducer/plugins/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="FWCore/Framework"/>
+<use name="DataFormats/HeavyIonEvent"/>
 <use name="DataFormats/VertexReco"/>
 <use name="DataFormats/HepMCCandidate"/>
 <use name="DataFormats/Luminosity"/>

--- a/VertexCompositeProducer/plugins/MultFilter.cc
+++ b/VertexCompositeProducer/plugins/MultFilter.cc
@@ -1,0 +1,237 @@
+// -*- C++ -*-
+//
+// Package:    VertexCompositeAnalysis/VertexCompositeProducer
+// Class:      MultFilter
+// 
+/**\class MultFilter MultFilter.cc VertexCompositeAnalysis/VertexCompositeProducer/plugins/MultFilter.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Yousen Zhang
+//         Created:  Thu, 12 Nov 2020 05:06:49 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+#include <limits>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
+
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/HeavyIonEvent/interface/CentralityBins.h"
+#include "DataFormats/HeavyIonEvent/interface/Centrality.h"
+#include "DataFormats/HeavyIonEvent/interface/EvtPlane.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+//
+// class declaration
+//
+
+class MultFilter : public edm::stream::EDFilter<> {
+   public:
+      explicit MultFilter(const edm::ParameterSet&);
+      ~MultFilter();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+   private:
+      virtual void beginStream(edm::StreamID) override;
+      virtual bool filter(edm::Event&, const edm::EventSetup&) override;
+      virtual void endStream() override;
+
+      //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+      //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+      //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+      //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+
+      // ----------member data ---------------------------
+      const edm::EDGetTokenT<reco::VertexCollection> tok_offlinePV_;
+      const edm::EDGetTokenT<edm::ValueMap<int> > tok_nTracksVMap_;
+      edm::ValueMap<int> nTracksVMap_;
+      int nMultMin_, nMultMax_;
+
+      bool useCent_;
+      const edm::EDGetTokenT<reco::Centrality> tok_centSrc_;
+      const edm::EDGetTokenT<int> tok_centBin_;
+      int centBinMin_, centBinMax_;
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+MultFilter::MultFilter(const edm::ParameterSet& iConfig) :
+  tok_offlinePV_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("primaryVertices"))),
+  tok_nTracksVMap_(consumes<edm::ValueMap<int> >(iConfig.getParameter<edm::InputTag>("nTracksVMap"))),
+  nMultMin_(iConfig.getUntrackedParameter<int>("nMultMin", 0)),
+  nMultMax_(iConfig.getUntrackedParameter<int>("nMultMax", std::numeric_limits<int>::max())),
+  useCent_(iConfig.getUntrackedParameter<bool>("useCent", false)),
+  tok_centSrc_(consumes<reco::Centrality>(iConfig.getUntrackedParameter<edm::InputTag>("centrality"))),
+  tok_centBin_(consumes<int>(iConfig.getUntrackedParameter<edm::InputTag>("centralityBin"))),
+  centBinMin_(iConfig.getUntrackedParameter<int>("centBinMin", 0)),
+  centBinMax_(iConfig.getUntrackedParameter<int>("centBinMax", std::numeric_limits<int>::max()))
+{
+   //now do what ever initialization is needed
+}
+
+
+MultFilter::~MultFilter()
+{
+ 
+   // do anything here that needs to be done at destruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called on each new Event  ------------
+bool
+MultFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  edm::Handle<reco::VertexCollection> vertexHandle;
+  iEvent.getByToken(tok_offlinePV_, vertexHandle);
+  edm::Handle<edm::ValueMap<int> > nTracksVMap;
+  iEvent.getByToken(tok_nTracksVMap_, nTracksVMap);
+
+  if (!useCent_) {
+    // do not use centrality
+    if (nTracksVMap.isValid() ) { nTracksVMap_ = *nTracksVMap; }
+    else {
+      return false;
+    }
+
+    bool isFail = true;
+    if (vertexHandle.isValid() && vertexHandle->size()) {
+      for (size_t ivtx=0; ivtx<vertexHandle->size(); ivtx++) {
+        reco::VertexRef vtxRef(vertexHandle, ivtx);
+        const auto& ntrk = nTracksVMap_[vtxRef];
+        if (ntrk >= nMultMin_ && ntrk < nMultMax_) {
+          isFail = false;
+          break;
+        }
+      }
+      if (isFail) return false;
+    } else {
+      return false;
+    }
+  }
+  else {
+    // use centrality
+    edm::Handle<reco::Centrality> cent;
+    iEvent.getByToken(tok_centSrc_, cent);
+    edm::Handle<int> centBin;
+    iEvent.getByToken(tok_centBin_, centBin);
+    const auto ntrk = cent->Ntracks();
+    if (ntrk < nMultMin_ || ntrk >= nMultMax_) {
+      LogDebug("MultFilter") << "UseCent=True, Ntrk: " << ntrk
+        << ", nMultMin: "<< nMultMin_ << ", nMultMax: " << nMultMax_
+        << ", Failed"<< std::endl;
+      return false;
+    }
+    if (*centBin < centBinMin_ || *centBin >= centBinMax_) {
+      LogDebug("MultFilter") << "UseCent=True, centBin: " << *centBin
+        << ", centBinMin: "<< centBinMin_ << ", centBinMax: " << centBinMax_
+        << ", Failed." << std::endl;
+      return false;
+    }
+    LogDebug("MultFilter") << "UseCent=True, Ntrk: " << ntrk
+      << ", nMultMin: "<< nMultMin_ << ", nMultMax: " << nMultMax_
+      << ", centBin: " << *centBin
+      << ", centBinMin: "<< centBinMin_ << ", centBinMax: " << centBinMax_
+      << ", Passed." << std::endl;
+  }
+
+  return true;
+}
+
+// ------------ method called once each stream before processing any runs, lumis or events  ------------
+void
+MultFilter::beginStream(edm::StreamID)
+{
+}
+
+// ------------ method called once each stream after processing all runs, lumis and events  ------------
+void
+MultFilter::endStream() {
+}
+
+// ------------ method called when starting to processes a run  ------------
+/*
+void
+MultFilter::beginRun(edm::Run const&, edm::EventSetup const&)
+{ 
+}
+*/
+ 
+// ------------ method called when ending the processing of a run  ------------
+/*
+void
+MultFilter::endRun(edm::Run const&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+void
+MultFilter::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+void
+MultFilter::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+MultFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  //desc.setUnknown();
+  desc.add<edm::InputTag>("primaryVertices", edm::InputTag("offlinePrimaryVertices"))->setComment("primary vertex collection");
+  desc.add<edm::InputTag>("nTracksVMap", edm::InputTag("generalParticles", "nTracks"))->setComment("Ntrk ValueMap");
+  desc.addUntracked<int>("nMultMin", 0)->setComment(">=");
+  desc.addUntracked<int>("nMultMax", std::numeric_limits<int>::max())->setComment("<");
+  desc.addUntracked<bool>("useCent", false);
+  desc.addUntracked<edm::InputTag>("centrality", edm::InputTag("hiCentrality"));
+  desc.addUntracked<edm::InputTag>("centralityBin", edm::InputTag("centralityBin","HFtowers"));
+  desc.addUntracked<int>("centBinMin", 0)->setComment(">=");
+  desc.addUntracked<int>("centBinMax", std::numeric_limits<int>::max())->setComment("<");
+  //descriptions.addDefault(desc);
+  descriptions.add("ntrkFilter", desc);
+}
+//define this as a plug-in
+DEFINE_FWK_MODULE(MultFilter);

--- a/VertexCompositeProducer/plugins/NTrackVertexMapper.cc
+++ b/VertexCompositeProducer/plugins/NTrackVertexMapper.cc
@@ -45,7 +45,7 @@ void NTrackVertexMapper::produce(edm::Event& iEvent, const edm::EventSetup& iSet
   std::vector<int> vtxNTrk((vertexHandle.isValid() ? vertexHandle->size() : 0), 0);
 
   // loop over general tracks
-  if (vertexHandle.isValid() && trackHandle.isValid() && vertexHandle->size()>1) {
+  if (vertexHandle.isValid() && trackHandle.isValid() && vertexHandle->size()) {
     for (const auto& trk : *trackHandle) {
       if (!trk.quality(reco::TrackBase::highPurity)) continue;
       if (trk.pt() <= 0.4 || std::abs(trk.eta()) >= 2.4) continue;

--- a/VertexCompositeProducer/python/generalParticles_cfi.py
+++ b/VertexCompositeProducer/python/generalParticles_cfi.py
@@ -33,5 +33,5 @@ generalParticles = cms.EDProducer("ParticleProducer",
     jets = cms.InputTag(''),
     conversions = cms.InputTag(''),
     mva = cms.InputTag(''),
-    dedxHarmonic2 = cms.InputTag(''),
+    dEdxInputs = cms.vstring(),
 )

--- a/VertexCompositeProducer/python/generalParticles_cfi.py
+++ b/VertexCompositeProducer/python/generalParticles_cfi.py
@@ -4,6 +4,7 @@ generalParticles = cms.EDProducer("ParticleProducer",
 
     pdgId = cms.int32(0),
     doSwap = cms.bool(False),
+    vtxSortByTrkSize = cms.bool(True),
 
     # particle selection
     preSelection = cms.string(""),

--- a/VertexCompositeProducer/python/ntrkUtils_cff.py
+++ b/VertexCompositeProducer/python/ntrkUtils_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+from VertexCompositeAnalysis.VertexCompositeProducer.ntrkUtils_cfi import *

--- a/VertexCompositeProducer/python/ntrkUtils_cfi.py
+++ b/VertexCompositeProducer/python/ntrkUtils_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+nTracks = cms.EDProducer('NTrackVertexMapper',
+  primaryVertices = cms.InputTag('offlinePrimaryVertices'),
+  tracks = cms.InputTag('generalTracks')
+)
+
+ntrkFilter = cms.EDFilter('MultFilter',
+  primaryVertices = cms.InputTag('offlinePrimaryVertices'),
+  nTracksVMap = cms.InputTag('generalParticles', 'nTracks'),
+  nMultMin = cms.untracked.int32(0), # >=
+  nMultMax = cms.untracked.int32(2147483647), # <
+  useCent = cms.untracked.bool(False),
+  centrality = cms.untracked.InputTag('hiCentrality'),
+  centralityBin = cms.untracked.InputTag('centralityBin', 'HFtowers'),
+  centBinMin = cms.untracked.int32(0), # >=
+  centBinMax = cms.untracked.int32(2147483647) # <
+)

--- a/VertexCompositeProducer/python/ntrkUtils_cfi.py
+++ b/VertexCompositeProducer/python/ntrkUtils_cfi.py
@@ -7,7 +7,7 @@ nTracks = cms.EDProducer('NTrackVertexMapper',
 
 ntrkFilter = cms.EDFilter('MultFilter',
   primaryVertices = cms.InputTag('offlinePrimaryVertices'),
-  nTracksVMap = cms.InputTag('generalParticles', 'nTracks'),
+  nTracksVMap = cms.InputTag('nTracks'),
   nMultMin = cms.untracked.int32(0), # >=
   nMultMax = cms.untracked.int32(2147483647), # <
   useCent = cms.untracked.bool(False),

--- a/VertexCompositeProducer/src/ParticleFitter.cc
+++ b/VertexCompositeProducer/src/ParticleFitter.cc
@@ -14,6 +14,7 @@
 ParticleFitter::ParticleFitter(const edm::ParameterSet& theParameters, edm::ConsumesCollector && iC) :
   pdgId_(theParameters.getParameter<int>("pdgId")),
   doSwap_(theParameters.getParameter<bool>("doSwap")),
+  vtxSortByTrkSize_(theParameters.getParameter<bool>("vtxSortByTrkSize")),
   preSelection_(theParameters.getParameter<std::string>("preSelection")),
   preMassSelection_(theParameters.getParameter<std::string>("preMassSelection")),
   pocaSelection_(theParameters.getParameter<std::string>("pocaSelection")),
@@ -144,8 +145,10 @@ void ParticleFitter::setVertex(const edm::Event& iEvent)
       vertexRefMap_[tp] = reco::VertexRef(vertexHandle, iVtx);
     }
   }
-  auto byTracksSize = [] (const reco::Vertex& v1, const reco::Vertex& v2) -> bool { return v1.tracksSize() > v2.tracksSize(); };
-  std::sort(priVertices_.begin(), priVertices_.end(), byTracksSize);
+  if (vtxSortByTrkSize_) {
+    auto byTracksSize = [] (const reco::Vertex& v1, const reco::Vertex& v2) -> bool { return v1.tracksSize() > v2.tracksSize(); };
+    std::sort(priVertices_.begin(), priVertices_.end(), byTracksSize);
+  }
   // set the primary vertex
   const auto beamSpotVertex = reco::Vertex(beamSpotHandle->position(), beamSpotHandle->rotatedCovariance3D());
   vertex_ = (priVertices_.empty() ? beamSpotVertex : priVertices_[0]);

--- a/VertexCompositeProducer/src/ParticleFitter.cc
+++ b/VertexCompositeProducer/src/ParticleFitter.cc
@@ -276,8 +276,9 @@ void ParticleFitter::makeCandidates()
     if (!preSelection_(cand)) continue;
     // check if grandaughters are unique
     bool hasDuplicate = false;
+    ParticleSet finalStateColl;
     for (const auto& dau : daughters) {
-      if (dau.hasUserData("daughters") && !isUniqueDaughter(daughters, dau)) { hasDuplicate = true; break; }
+      if (!isUniqueDaughter(finalStateColl, dau)) { hasDuplicate = true; break; }
     }
     if (hasDuplicate) continue;
     // extract daughter information
@@ -799,8 +800,10 @@ void ParticleDaughter::fillInfo(const edm::ParameterSet& pSet, const edm::Parame
   if (mvaSet.existsAs<edm::InputTag>("mva")) {
     token_mva_ = iC.consumes<std::vector<float> >(mvaSet.getParameter<edm::InputTag>("mva"));
   }
-  if (config.existsAs<edm::InputTag>("dedxHarmonic2")) {
-    token_dedx_ = iC.consumes<edm::ValueMap<reco::DeDxData> >(config.getParameter<edm::InputTag>("dedxHarmonic2"));
+  if (config.existsAs<std::vector<std::string> >("dEdxInputs")) {
+    for (const auto& input : config.getParameter<std::vector<std::string> >("dEdxInputs")){
+      tokens_dedx_.insert( std::make_pair(input, iC.consumes<edm::ValueMap<reco::DeDxData> >(edm::InputTag(input))));
+    }
   }
   if (std::abs(pdgId_)==13 && (!pSet.existsAs<bool>("propToMuon") || pSet.getParameter<bool>("propToMuon"))) {
     conf_.addParameter("useSimpleGeometry", (pSet.existsAs<bool>("useSimpleGeometry") ? pSet.getParameter<bool>("useSimpleGeometry") : true)); // default: true
@@ -828,8 +831,14 @@ void ParticleDaughter::addParticles(const edm::Event& event, const edm::EDGetTok
   // extract input collections
   edm::Handle<std::vector<T> > handle;
   if (!token.isUninitialized()) event.getByToken(token, handle);
-  edm::Handle<edm::ValueMap<reco::DeDxData> > dEdxMap;
-  if (!token_dedx_.isUninitialized()) event.getByToken(token_dedx_, dEdxMap);
+  std::map<std::string, edm::Handle<edm::ValueMap<reco::DeDxData> > > dEdxMaps;
+  for (const auto& tokenMap : tokens_dedx_) {
+    if (!tokenMap.second.isUninitialized()) {
+      edm::Handle<edm::ValueMap<reco::DeDxData> > dEdxMapTemp;
+      event.getByToken(tokenMap.second, dEdxMapTemp);
+      dEdxMaps.insert ( std::make_pair( tokenMap.first, dEdxMapTemp) );
+    }
+  }
   edm::Handle<std::vector<float> > mvaColl;
   if (!token_mva_.isUninitialized()) event.getByToken(token_mva_, mvaColl);
   // set selections
@@ -860,7 +869,7 @@ void ParticleDaughter::addParticles(const edm::Event& event, const edm::EDGetTok
       }
       else if (cand.charge()!=0) continue; // ignore if charged particle has no track
       cand.addUserFloat("width", width_);
-      setDeDx(cand, dEdxMap);
+      setDeDx(cand, dEdxMaps);
       setMVA(cand, i, mvaColl);
       if (finalSelection(cand)) {
         particles.insert(cand);
@@ -999,12 +1008,16 @@ void ParticleDaughter::setMVA(pat::GenericParticle& c, const size_t& i, const ed
 };
 
 
-void ParticleDaughter::setDeDx(pat::GenericParticle& c, const edm::Handle<edm::ValueMap<reco::DeDxData> >& dEdxMap)
+void ParticleDaughter::setDeDx(pat::GenericParticle& c,
+    const std::map<std::string, edm::Handle<edm::ValueMap<reco::DeDxData> > >& dEdxMaps)
 {
   const auto& track = (c.hasUserData("trackRef") ? *c.userData<reco::TrackRef>("trackRef") : c.track());
   if (track.isNull()) return;
-  if (dEdxMap.isValid() && dEdxMap->contains(track.id())) {
-    const auto& dEdx = (*dEdxMap)[track].dEdx();
-    c.addUserFloat("dEdx", dEdx);
+  for (const auto& dEdxMapPair : dEdxMaps) {
+    const auto& dEdxMap = dEdxMapPair.second;
+    if (dEdxMap.isValid() && dEdxMap->contains(track.id())) {
+      const auto& dEdx = (*dEdxMap)[track].dEdx();
+      c.addUserFloat("dEdx_"+dEdxMapPair.first, dEdx);
+    }
   }
 };

--- a/VertexCompositeProducer/src/ParticleFitter.cc
+++ b/VertexCompositeProducer/src/ParticleFitter.cc
@@ -347,8 +347,8 @@ void ParticleFitter::swapDaughters(DoubleMap& swapDauColls, const pat::GenericPa
       const auto& per = perColl[i];
       const auto& sourceID1 = (dau.hasUserInt("sourceID") ? dau.userInt("sourceID") : 0);
       const auto& sourceID2 = (per.hasUserInt("sourceID") ? per.userInt("sourceID") : 0);
-      if (sourceID1!=sourceID2) break;
-      if (sourceID1==0 && !ParticleComparator().isParticleEqual(dau, per)) break;
+      if (sourceID1!=sourceID2 || sourceID1==0) break; // sourceID == 0 means that the daughter has PID, not necessary to swap it with another
+      if (abs(dau.pdgId()) == abs(per.pdgId())) break; // if the swapped daughter is identical to the original one, not necessary to swap
       if (cand.charge()!=0 && dau.charge()!=per.charge()) break;
       swapDauColl.push_back(per.mass());
       p4 += math::XYZTLorentzVector(dau.px(), dau.py(), dau.pz(), std::sqrt(dau.p4().P2()+per.massSqr()));
@@ -963,6 +963,7 @@ void ParticleDaughter::addData(pat::GenericParticle& c, const reco::PFCandidateR
   c.setTrack(p->trackRef(), embedInfo);
   if (embedInfo) c.addUserData<reco::TrackRef>("trackRef", p->trackRef());
   c.addUserData<reco::PFCandidate>("src", *p);
+  c.addUserInt("sourceID", 2);
 };
 
 

--- a/VertexCompositeProducer/test/CESAR.py
+++ b/VertexCompositeProducer/test/CESAR.py
@@ -166,7 +166,7 @@ process.d0rereco_step = cms.Path(process.eventFilter_HM * process.generalD0Candi
 
 # Define the output
 process.TFileService = cms.Service("TFileService",
-                                       fileName = cms.string('d0ana_PbPb2018.root')
+                                       fileName = cms.string('d0ana_PbPb2018_CESAR.root')
                                   )
 
 

--- a/VertexCompositeProducer/test/PbPbSkimAndNtuple2018_LambdaCtoKsProton_ParticleAnalyzer_cfg.py
+++ b/VertexCompositeProducer/test/PbPbSkimAndNtuple2018_LambdaCtoKsProton_ParticleAnalyzer_cfg.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.Eras import eras
-process = cms.Process('D0PbPb2018SKIM',eras.Run2_2018_pp_on_AA)
+process = cms.Process('LambdaCPbPb2018SKIM',eras.Run2_2018_pp_on_AA)
 
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
@@ -9,27 +9,18 @@ process.load('Configuration.StandardSequences.Reconstruction_cff')
 process.load("CondCore.CondDB.CondDB_cfi")
 process.load('Configuration.EventContent.EventContent_cff')
 
+
 # Limit the output messages
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+process.options = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
 
-process.options = cms.untracked.PSet(
-    wantSummary = cms.untracked.bool( True ),
-)
-
+# Define the input source
 process.source = cms.Source("PoolSource",
-   fileNames = cms.untracked.vstring(
-###'/store/hidata/HIRun2018A/HIMinimumBias1/AOD/PromptReco-v1/000/326/577/00000/532A6440-350D-2446-89FB-3CA9E8335E4F.root'
-##'/store/hidata/HIRun2018A/HIMinimumBias6/AOD/04Apr2019-v1/70012/FEB2298F-D3AA-5A41-A999-02AEC7648569.root'
-'file:output_numEvent100.root'
-#'root://cmsxrootd.fnal.gov//store/hidata/HIRun2018A/HISingleMuon/AOD/04Apr2019-v1/270003/21A8A05E-B3C5-4445-A76E-1433602ED7FF.root'
-   ),
+    fileNames = cms.untracked.vstring('file:output_numEvent100.root'),
 )
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(100))
 
-#Setup FWK for multithreaded
-#process.options.numberOfThreads=cms.untracked.uint32(8)
-#process.options.numberOfStreams=cms.untracked.uint32(0)
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 
 # Set the global tag
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
@@ -95,82 +86,76 @@ process.lumiInfo = cms.EDProducer('LumiProducerFromBrilcalc',
                                   doBunchByBunch = cms.bool(False))
 process.lumi_seq = cms.Sequence(process.lumiInfo)
 
+# Add the VertexComposite producer
+from VertexCompositeAnalysis.VertexCompositeProducer.generalParticles_cff import generalParticles
 
-# D0 candidate rereco
-process.load("VertexCompositeAnalysis.VertexCompositeProducer.generalParticles_cff")
-process.generalD0CandidatesNew = process.generalParticles.clone(
-    pdgId = cms.int32(421),
-    doSwap = cms.bool(True),
-    width = cms.double(0.15),
+process.kShort = generalParticles.clone(
+    pdgId = cms.int32(310),
+    charge = cms.int32(0),
+    doSwap = cms.bool(False),
+    width = cms.double(0.2),
 
-    preSelection = cms.string(""
-       "charge==0"
-       "&& userFloat('dauPtSum') >= 1.6 && userFloat('dauEtaDiff') <= 1.0"
-       ),
-    pocaSelection = cms.string(""
-       "userFloat('bestMass') >= 1.71 && userFloat('bestMass') <= 2.02 && pt >= 1.0"
-       "&& userFloat('dca') >= 0 && userFloat('dca') <= 9999."
-       ),
-    postSelection = cms.string(""
-       "userFloat('vertexProb') >= 0.02"
-       "&& userFloat('normChi2') <= 9999.0"
-       ),
-    finalSelection = cms.string(""
-       "userFloat('rVtxMag') >= 0.0 && userFloat('rVtxSig') >= 2.0"
-       "&& userFloat('lVtxMag') >= 0.0 && userFloat('lVtxSig') >= 3.0"
-       "&& cos(userFloat('angle3D')) >= -2.0 && cos(userFloat('angle2D')) >= -2.0"
-       "&& abs(userFloat('angle3D')) <= 0.2 && abs(userFloat('angle2D')) <= 0.2"
-       "&& abs(rapidity) < 2.0"
-       ),
-    #dEdxInputs = cms.vstring('dedxHarmonic2', 'dedxPixelHarmonic2'),
-#
+    preSelection = cms.string(""),
+    pocaSelection = cms.string("pt >= 1.0 && abs(rapidity) < 2.4"),
+    postSelection = cms.string(""),
+    preMassSelection = cms.string(""),
+    finalSelection = cms.string( "abs(userFloat('angle3D'))<0.2 && abs(userFloat('lVtxSig'))>2.5 && cos(userFloat('angle3D'))>0.99999"),
+
+    dEdxInputs = cms.vstring('dedxHarmonic2', 'dedxPixelHarmonic2'),
+
     # daughter information
     daughterInfo = cms.VPSet([
-        cms.PSet(pdgId = cms.int32(321), charge = cms.int32(-1),
-           selection = cms.string(
-              "pt>1.0 && abs(eta)<2.4"
-              "&& quality('highPurity') && ptError/pt<0.1"
+        cms.PSet(pdgId = cms.int32(211), charge = cms.int32(-1),
+              selection = cms.string(
+              "pt>0.4 && abs(eta)<2.4"
+              "&& quality('loose')"" && ptError/pt<0.1"
+              "&& normalizedChi2<7.0"
               "&& (normalizedChi2/hitPattern.trackerLayersWithMeasurement)<0.18"
-              "&& numberOfValidHits >=11"
-              ),
-           finalSelection = cms.string(''
-              'abs(userFloat("dzSig")) < 3.0 && abs(userFloat("dxySig")) < 3.0'
-              '&& (track.algo!=6 || userFloat("mva")>=0.98)'
-              )
-           ),
+              "&& numberOfValidHits >=4"),
+              finalSelection = cms.string( "(track.algo!=6 || userFloat('mva')>=0.98)")
+            ),
         cms.PSet(pdgId = cms.int32(211), charge = cms.int32(+1),
-           selection = cms.string(
-              "pt>1.0 && abs(eta)<2.4"
-              "&& quality('highPurity') && ptError/pt<0.1"
+              selection = cms.string(
+              "pt>0.4 && abs(eta)<2.4"
+              "&& quality('loose')"" && ptError/pt<0.1"
+              "&& normalizedChi2<7.0"
               "&& (normalizedChi2/hitPattern.trackerLayersWithMeasurement)<0.18"
-              "&& numberOfValidHits >=11"
-              ),
-           finalSelection = cms.string(''
-              'abs(userFloat("dzSig")) < 3.0 && abs(userFloat("dxySig")) < 3.0'
-              '&& (track.algo!=6 || userFloat("mva")>=0.98)'
-              )
-           )
-    ])
-  )
-process.generalD0CandidatesNew.mva = cms.InputTag("generalTracks","MVAValues") ###cesar:to change iter6 tracking mva cut
-
-# tree producer
-
-process.load("VertexCompositeAnalysis.VertexCompositeAnalyzer.particle_tree_cff")
-process.particleAnaNew = process.particleAna.clone(
-  recoParticles = cms.InputTag("generalD0CandidatesNew"),
-  centralityBin = cms.untracked.InputTag("centralityBin","HFtowers"),
-  #eventFilterResults = cms.untracked.InputTag("TriggerResults::D0PbPb2018SKIM"),
-  selectEvents = cms.string("eventFilter_HM_step")
+              "&& numberOfValidHits >=4"),
+              finalSelection = cms.string( "(track.algo!=6 || userFloat('mva')>=0.98)")
+            ),
+    ]),
 )
+process.kShort.mva = cms.InputTag("generalTracks","MVAValues") ###cesar:to change iter6 tracking mva cut
 
-process.particleAnaNewSeq = cms.Sequence(process.particleAnaNew)
+process.LambdaC = generalParticles.clone(
+    pdgId = cms.int32(4122),
+    doSwap = cms.bool(False),
+    preSelection = cms.string("pt>5.0 && mass < 2.4 && mass>2.1"),
+    preMassSelection = cms.string("abs(charge)==1"),
+    finalSelection = cms.string(''),
+
+    dEdxInputs = cms.vstring('dedxHarmonic2', 'dedxPixelHarmonic2'),
+
+    # daughter information
+    daughterInfo = cms.VPSet([
+        cms.PSet(pdgId = cms.int32(310), source = cms.InputTag('kShort'), selection = cms.string('')),
+        cms.PSet(pdgId = cms.int32(2212), #charge = cms.int32(+1),
+          selection = cms.string("pt>0.4 && abs(eta)<2.4"
+              "&& quality('highPurity') && ptError/pt<0.1"
+              "&& normalizedChi2<7.0"
+              "&& (normalizedChi2/hitPattern.trackerLayersWithMeasurement)<0.18"
+              "&& numberOfValidHits >=11"),
+            finalSelection = cms.string("abs(userFloat('dzSig')) < 3 && abs(userFloat('dxySig')) < 3"
+              "&& (track.algo!=6 || userFloat('mva')>=0.98)"
+            )),
+    ]),
+)
+process.LambdaC.mva = cms.InputTag("generalTracks","MVAValues") ###cesar:to change iter6 tracking mva cut
 
 # Add PbPb collision event selection
 process.load("VertexCompositeAnalysis.VertexCompositeProducer.OfflinePrimaryVerticesRecovery_cfi")
 process.load('VertexCompositeAnalysis.VertexCompositeProducer.collisionEventSelection_cff')
 process.load('VertexCompositeAnalysis.VertexCompositeProducer.hfCoincFilter_cff')
-
 
 # Define the event selection sequence
 process.eventFilter_HM = cms.Sequence(
@@ -183,12 +168,21 @@ process.eventFilter_HM_step = cms.Path( process.eventFilter_HM )
 
 # Define the analysis steps
 process.pcentandep_step = cms.Path(process.eventFilter_HM * process.cent_seq * process.evtplane_seq * process.lumi_seq)
-process.d0rereco_step = cms.Path(process.eventFilter_HM * process.generalD0CandidatesNew)
+process.rereco_step = cms.Path(process.eventFilter_HM * process.kShort * process.LambdaC)
+
+# Add the VertexComposite tree
+from VertexCompositeAnalysis.VertexCompositeAnalyzer.particle_tree_cff import particleAna
+process.lambdacAna = particleAna.clone(
+  recoParticles = cms.InputTag("LambdaC"),
+  addSource    = cms.untracked.bool(False),
+  saveTree = cms.untracked.bool(False),
+  centralityBin = cms.untracked.InputTag("centralityBin","HFtowers"),
+  selectEvents = cms.string("eventFilter_HM_step")
+)
+process.particleAnaNewSeq = cms.Sequence(process.lambdacAna)
 
 # Define the output
-process.TFileService = cms.Service("TFileService",
-                                       fileName = cms.string('d0ana_PbPb2018.root')
-                                  )
+process.TFileService = cms.Service("TFileService", fileName = cms.string('lambdacana.root'))
 
 process.load("VertexCompositeAnalysis.VertexCompositeProducer.ppanalysisSkimContentD0_cff")
 process.output_HM = cms.OutputModule("PoolOutputModule",
@@ -200,24 +194,23 @@ process.output_HM = cms.OutputModule("PoolOutputModule",
     )
 )
 
-process.particleAna_step = cms.EndPath( process.particleAnaNewSeq )
-
-
 process.output_HM.outputCommands = cms.untracked.vstring(#'drop *',
-      'keep *_generalD0CandidatesNew__D0PbPb2018SKIM',
+      'keep *_LambdaC__LambdaCPbPb2018SKIM',
       'keep *_offlinePrimaryVerticesRecovery_*_*',
       'keep *_hiEvtPlane_*_*',
       'keep *_centralityBin_*_*',
-      'keep *_hiCentrality_*_D0PbPb2018SKIM',
+      'keep *_hiCentrality_*_LambdaCPbPb2018SKIM',
 )
+
 process.output_HM_step = cms.EndPath(process.output_HM)
 
+process.particleAna_step = cms.EndPath( process.particleAnaNewSeq )
 
 # Define the process schedule
 process.schedule = cms.Schedule(
     process.eventFilter_HM_step,
     process.pcentandep_step,
-    process.d0rereco_step,
+    process.rereco_step,
     process.output_HM_step,
     process.particleAna_step
 )

--- a/VertexCompositeProducer/test/PbPbSkimAndNtuple2018_Rho_cfg.py
+++ b/VertexCompositeProducer/test/PbPbSkimAndNtuple2018_Rho_cfg.py
@@ -1,0 +1,246 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+process = cms.Process('RhoPbPb2018SKIM',eras.Run2_2018_pp_on_AA)
+
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Reconstruction_cff')
+process.load("CondCore.CondDB.CondDB_cfi")
+process.load('Configuration.EventContent.EventContent_cff')
+
+
+# Limit the output messages
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+
+# DEBUG
+process.MessageLogger.cerr.threshold = "DEBUG"
+process.MessageLogger.debugModules = ["ntrkFilterRho"]
+
+process.options = cms.untracked.PSet(
+    wantSummary = cms.untracked.bool( True ),
+)
+
+process.source = cms.Source("PoolSource",
+   fileNames = cms.untracked.vstring(
+###'/store/hidata/HIRun2018A/HIMinimumBias1/AOD/PromptReco-v1/000/326/577/00000/532A6440-350D-2446-89FB-3CA9E8335E4F.root'
+#'/store/hidata/HIRun2018A/HIMinimumBias6/AOD/04Apr2019-v1/70012/FEB2298F-D3AA-5A41-A999-02AEC7648569.root'
+'file:output_numEvent100.root'
+   ),
+)
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(100))
+
+#Setup FWK for multithreaded
+#process.options.numberOfThreads=cms.untracked.uint32(8)
+#process.options.numberOfStreams=cms.untracked.uint32(0)
+
+# Set the global tag
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+process.GlobalTag.globaltag = cms.string('103X_dataRun2_v6')
+
+
+# Add PbPb centrality
+process.load("RecoHI.HiCentralityAlgos.CentralityBin_cfi")
+process.load('RecoHI.HiCentralityAlgos.HiCentrality_cfi')
+process.hiCentrality.produceHFhits = False
+process.hiCentrality.produceHFtowers = False
+process.hiCentrality.produceEcalhits = False
+process.hiCentrality.produceZDChits = False
+process.hiCentrality.produceETmidRapidity = False
+process.hiCentrality.producePixelhits = False
+process.hiCentrality.produceTracks = False
+process.hiCentrality.producePixelTracks = False
+process.hiCentrality.reUseCentrality = True
+process.hiCentrality.srcReUse = cms.InputTag("hiCentrality","","reRECO")
+process.centralityBin.Centrality = cms.InputTag("hiCentrality")
+process.centralityBin.centralityVariable = cms.string("HFtowers")
+process.centralityBin.nonDefaultGlauberModel = cms.string("")
+process.GlobalTag.snapshotTime = cms.string("9999-12-31 23:59:59.000")
+process.GlobalTag.toGet.extend([
+    cms.PSet(record = cms.string("HeavyIonRcd"),
+        tag = cms.string("CentralityTable_HFtowers200_DataPbPb_periHYDJETshape_run2v1031x02_offline"),
+        connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
+        label = cms.untracked.string("HFtowers")
+        ),
+    ])
+process.cent_seq = cms.Sequence(process.hiCentrality * process.centralityBin)
+
+
+# Add PbPb event plane
+process.load("RecoHI.HiEvtPlaneAlgos.HiEvtPlane_cfi")
+process.load("RecoHI.HiEvtPlaneAlgos.hiEvtPlaneFlat_cfi")
+process.hiEvtPlane.trackTag = cms.InputTag("generalTracks")
+process.hiEvtPlane.vertexTag = cms.InputTag("offlinePrimaryVerticesRecovery")
+process.hiEvtPlane.loadDB = cms.bool(True)
+process.hiEvtPlane.useNtrk = cms.untracked.bool(False)
+process.hiEvtPlane.caloCentRef = cms.double(-1)
+process.hiEvtPlane.caloCentRefWidth = cms.double(-1)
+process.hiEvtPlaneFlat.caloCentRef = cms.double(-1)
+process.hiEvtPlaneFlat.caloCentRefWidth = cms.double(-1)
+process.hiEvtPlaneFlat.vertexTag = cms.InputTag("offlinePrimaryVerticesRecovery")
+process.hiEvtPlaneFlat.useNtrk = cms.untracked.bool(False)
+process.CondDB.connect = "sqlite_file:HeavyIonRPRcd_PbPb2018_offline.db"
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+                                       process.CondDB,
+                                       toGet = cms.VPSet(cms.PSet(record = cms.string('HeavyIonRPRcd'),
+                                                                  tag = cms.string('HeavyIonRPRcd_PbPb2018_offline')
+                                                                  )
+                                                         )
+                                      )
+process.es_prefer_flatparms = cms.ESPrefer('PoolDBESSource','')
+process.evtplane_seq = cms.Sequence(process.hiEvtPlane * process.hiEvtPlaneFlat)
+
+
+# Rho candidate rereco
+process.load("VertexCompositeAnalysis.VertexCompositeProducer.generalParticles_cff")
+process.generalRhoCandidatesNew = process.generalParticles.clone(
+    pdgId = cms.int32(113),
+    mass = cms.double(0.775),
+    charge = cms.int32(0),
+    doSwap = cms.bool(True),
+    width = cms.double(1.3),
+
+    preSelection = cms.string(""
+       "charge==0"
+       "&& userFloat('dauPtSum') >= 1.6 && userFloat('dauEtaDiff') <= 1.0"
+       ),
+    pocaSelection = cms.string(""
+       "userFloat('bestMass') >= 0. && userFloat('bestMass') <= 2.02 && pt >= 1.0"
+       "&& userFloat('dca') >= 0 && userFloat('dca') <= 9999."
+       ),
+    postSelection = cms.string(""
+       "userFloat('vertexProb') >= 0.02"
+       "&& userFloat('normChi2') <= 9999.0"
+       ),
+    finalSelection = cms.string(""
+       "userFloat('rVtxMag') >= 0.0 && userFloat('rVtxSig') >= 2.0"
+       "&& userFloat('lVtxMag') >= 0.0 && userFloat('lVtxSig') >= 3.0"
+       "&& cos(userFloat('angle3D')) >= -2.0 && cos(userFloat('angle2D')) >= -2.0"
+       "&& abs(userFloat('angle3D')) <= 0.2 && abs(userFloat('angle2D')) <= 0.2"
+       "&& abs(rapidity) < 2.0"
+       ),
+#
+    # daughter information
+    daughterInfo = cms.VPSet([
+        cms.PSet(pdgId = cms.int32(211), charge = cms.int32(-1),
+           selection = cms.string(
+              "pt>1.0 && abs(eta)<2.4"
+              "&& quality('highPurity') && ptError/pt<0.1"
+              "&& (normalizedChi2/hitPattern.trackerLayersWithMeasurement)<0.18"
+              "&& numberOfValidHits >=11"
+              ),
+           finalSelection = cms.string(''
+              'abs(userFloat("dzSig")) < 3.0 && abs(userFloat("dxySig")) < 3.0'
+              '&& (track.algo!=6 || userFloat("mva")>=0.98)'
+              )
+           ),
+        cms.PSet(pdgId = cms.int32(211), charge = cms.int32(+1),
+           selection = cms.string(
+              "pt>1.0 && abs(eta)<2.4"
+              "&& quality('highPurity') && ptError/pt<0.1"
+              "&& (normalizedChi2/hitPattern.trackerLayersWithMeasurement)<0.18"
+              "&& numberOfValidHits >=11"
+              ),
+           finalSelection = cms.string(''
+              'abs(userFloat("dzSig")) < 3.0 && abs(userFloat("dxySig")) < 3.0'
+              '&& (track.algo!=6 || userFloat("mva")>=0.98)'
+              )
+           )
+    ])
+  )
+process.generalRhoCandidatesNew.mva = cms.InputTag("generalTracks","MVAValues") ###cesar:to change iter6 tracking mva cut
+
+# tree producer
+from VertexCompositeAnalysis.VertexCompositeAnalyzer.particle_tree_cff import particleAna
+process.generalanaNew = particleAna.clone(
+  recoParticles = cms.InputTag("generalRhoCandidatesNew"),
+  triggerInfo = cms.untracked.VPSet([
+    cms.PSet(path = cms.string('HLT_HIMinimumBias_*')), # Minimum bias
+  ]),
+  selectEvents = cms.string("ntrkFilterRho_step"),
+)
+
+process.generalanaNewSeq = cms.Sequence(process.generalanaNew)
+process.generalana_step = cms.EndPath( process.generalanaNewSeq )
+
+# Add PbPb collision event selection
+process.load("VertexCompositeAnalysis.VertexCompositeProducer.OfflinePrimaryVerticesRecovery_cfi")
+process.load('VertexCompositeAnalysis.VertexCompositeProducer.collisionEventSelection_cff')
+process.load('VertexCompositeAnalysis.VertexCompositeProducer.hfCoincFilter_cff')
+
+process.load('VertexCompositeAnalysis.VertexCompositeProducer.ntrkUtils_cff')
+
+# Define the event selection sequence
+
+process.ntrkFilterRho = process.ntrkFilter.clone(
+      useCent = cms.untracked.bool(True),
+      nMultMin = cms.untracked.int32(0), # >=
+      nMultMax = cms.untracked.int32(200), # <
+      centBinMin = cms.untracked.int32(100), # >=
+      centBinMax = cms.untracked.int32(200) # <
+    )
+
+process.ntrkFilterRho_seq = cms.Sequence(process.ntrkFilterRho)
+
+process.eventFilter_HM = cms.Sequence(
+    process.offlinePrimaryVerticesRecovery *
+    process.hfCoincFilter2Th4 *
+    process.primaryVertexFilter *
+    process.clusterCompatibilityFilter
+)
+
+process.eventFilter_HM_step = cms.Path( process.eventFilter_HM )
+process.ntrkFilterRho_step = cms.Path(process.eventFilter_HM * process.ntrkFilterRho_seq)
+
+# Define the analysis steps
+process.pcentandep_step = cms.Path(process.eventFilter_HM * process.cent_seq * process.evtplane_seq * process.ntrkFilterRho_seq)
+process.rhorereco_step = cms.Path(process.eventFilter_HM * process.ntrkFilterRho_seq* process.generalRhoCandidatesNew)
+
+# Define the output
+process.TFileService = cms.Service("TFileService",
+                                       fileName = cms.string('rhoana_PbPb2018.root')
+                                  )
+
+process.output_HM = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('PbPb2018_SKIM_AOD.root'),
+    SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('eventFilter_HM_step', 'ntrkFilterRho_step')),
+    dataset = cms.untracked.PSet(
+      dataTier = cms.untracked.string('AOD')
+    )
+)
+process.output_HM.outputCommands = cms.untracked.vstring('drop *',
+      'keep *_*_*_RhoPbPb2018SKIM',
+      'keep *_offlinePrimaryVerticesRecovery_*_*',
+      'keep *_hiEvtPlane_*_*',
+      'keep *_centralityBin_*_*',
+      'keep *_hiCentrality_*_RhoPbPb2018SKIM',
+)
+
+
+process.output_HM_step = cms.EndPath(process.output_HM)
+
+# Define the process schedule
+process.schedule = cms.Schedule(
+    process.eventFilter_HM_step,
+    process.pcentandep_step,
+    process.ntrkFilterRho_step,
+    process.rhorereco_step,
+    process.output_HM_step,
+    process.generalana_step
+)
+
+# Add the event selection filters
+process.colEvtSel = cms.Sequence(process.hfCoincFilter2Th4 * process.primaryVertexFilter * process.clusterCompatibilityFilter)
+process.Flag_colEvtSel = cms.Path(process.eventFilter_HM * process.colEvtSel)
+process.Flag_hfCoincFilter2Th4 = cms.Path(process.eventFilter_HM * process.hfCoincFilter2Th4)
+process.Flag_primaryVertexFilter = cms.Path(process.eventFilter_HM * process.primaryVertexFilter)
+process.Flag_clusterCompatibilityFilter = cms.Path(process.eventFilter_HM * process.clusterCompatibilityFilter)
+eventFilterPaths = [ process.Flag_colEvtSel , process.Flag_hfCoincFilter2Th4 , process.Flag_primaryVertexFilter , process.Flag_clusterCompatibilityFilter ]
+for P in eventFilterPaths:
+      process.schedule.insert(0, P)
+
+# peripheral pv recovery
+from HLTrigger.Configuration.CustomConfigs import MassReplaceInputTag
+process = MassReplaceInputTag(process,"offlinePrimaryVertices","offlinePrimaryVerticesRecovery")
+process.offlinePrimaryVerticesRecovery.oldVertexLabel = "offlinePrimaryVertices"

--- a/VertexCompositeProducer/test/PbPbSkimAndTree2018_D0_CutBasedSelectionForEDM_BDTselectionForTree_17Jun2019Production.py
+++ b/VertexCompositeProducer/test/PbPbSkimAndTree2018_D0_CutBasedSelectionForEDM_BDTselectionForTree_17Jun2019Production.py
@@ -32,8 +32,8 @@ process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(100))
 #process.options.numberOfStreams=cms.untracked.uint32(0)
 
 # DEBUG
-process.MessageLogger.cerr.threshold = "DEBUG"
-process.MessageLogger.debugModules = ["ntrkFilterD0"]
+#process.MessageLogger.cerr.threshold = "DEBUG"
+#process.MessageLogger.debugModules = ["ntrkFilterD0"]
 
 # Set the global tag
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
@@ -183,8 +183,8 @@ process.ntrkFilterD0 = process.ntrkFilter.clone(
       useCent = cms.untracked.bool(False),
       vtxSortByTrkSize = cms.untracked.bool(False),
       nTracksVMap = cms.InputTag('nTracksD0'),
-      nMultMin = cms.untracked.int32(0), # >=
-      nMultMax = cms.untracked.int32(200), # <
+      #nMultMin = cms.untracked.int32(0), # >=
+      #nMultMax = cms.untracked.int32(200), # <
     )
 
 process.ntrkFilterD0_seq = cms.Sequence(process.nTracksD0 * process.ntrkFilterD0)

--- a/VertexCompositeProducer/test/PbPbSkimAndTree2018_Rho_cfg.py
+++ b/VertexCompositeProducer/test/PbPbSkimAndTree2018_Rho_cfg.py
@@ -154,7 +154,6 @@ process.generalRhoCandidatesNew.mva = cms.InputTag("generalTracks","MVAValues") 
 # tree producer
 from VertexCompositeAnalysis.VertexCompositeAnalyzer.particle_tree_cff import particleAna
 process.generalanaNew = particleAna.clone(
-    saveTree = False,
   recoParticles = cms.InputTag("generalRhoCandidatesNew"),
   triggerInfo = cms.untracked.VPSet([
     cms.PSet(path = cms.string('HLT_HIMinimumBias_*')), # Minimum bias
@@ -200,7 +199,7 @@ process.rhorereco_step = cms.Path(process.eventFilter_HM * process.ntrkFilterRho
 
 # Define the output
 process.TFileService = cms.Service("TFileService",
-                                       fileName = cms.string('rhoana_ntuple_PbPb2018.root')
+                                       fileName = cms.string('rhoana_tree_PbPb2018.root')
                                   )
 
 process.output_HM = cms.OutputModule("PoolOutputModule",


### PR DESCRIPTION
Added the feature reading dedx from multiple sources. Fix the bug when creating two-layer decay particles.
Test the 100 events for D0 production. It gives the same p4 and primary vertex info of each D0 candidate. Dedx information are also identical. Checked the output tree structure of lambdaC->KsProton and it looks normal to me.