### PR TITLE
fix a bug related to *_candIdx

### DIFF
--- a/VertexCompositeAnalyzer/plugins/ParticleAnalyzer.cc
+++ b/VertexCompositeAnalyzer/plugins/ParticleAnalyzer.cc
@@ -446,6 +446,7 @@ private:
       for (const auto& d : data_.uintVM()  ) { uintVVM_[d.first].push_back(d.second);   }
       for (const auto& d : data_.floatVM() ) { floatVVM_[d.first].push_back(d.second);  }
       parM_[par] = size_++;
+      data_.clear();
     };
 
     void copyData(Container& data, const size_t& i, const std::string& n="") const
@@ -462,8 +463,6 @@ private:
     };
 
     // clear
-    void clearTemp() { data_.clear(); }
-
     void clear()
     {
       size_ = 0;
@@ -1255,7 +1254,6 @@ ParticleAnalyzer::fillTriggerObjectInfo(const pat::TriggerObjectStandAlone& obj,
 
   // push data and return index
   info.pushData(obj);
-  info.clearTemp();
   return idx;
 }
 
@@ -1422,7 +1420,6 @@ ParticleAnalyzer::fillRecoParticleInfo(const pat::GenericParticle& cand, const U
     }
   }
 
-  info.clearTemp();
   // return index
   return idx;
 }
@@ -1575,7 +1572,6 @@ ParticleAnalyzer::fillTrackInfo(const pat::GenericParticle& cand, const UShort_t
 
   // push data and return index
   info.pushData(cand);
-  info.clearTemp(); 
   return idx;
 }
 
@@ -1726,7 +1722,6 @@ ParticleAnalyzer::fillMuonInfo(const pat::GenericParticle& cand, const UShort_t&
 
   // push data and return index
   info.pushData(cand);
-  info.clearTemp();
   return idx;
 };
 
@@ -1773,7 +1768,6 @@ ParticleAnalyzer::fillElectronInfo(const pat::GenericParticle& cand, const UShor
 
   // push data and return index
   info.pushData(cand);
-  info.clearTemp();
   return idx;
 };
 
@@ -1831,7 +1825,6 @@ ParticleAnalyzer::fillPhotonInfo(const pat::GenericParticle& cand, const UShort_
 
   // push data and return index
   info.pushData(cand);
-  info.clearTemp();
   return idx;
 };
 
@@ -1891,7 +1884,6 @@ ParticleAnalyzer::fillJetInfo(const pat::GenericParticle& cand, const UShort_t& 
 
   // push data and return index
   info.pushData(cand);
-  info.clearTemp();
   return idx;
 };
 
@@ -1925,7 +1917,6 @@ ParticleAnalyzer::fillTauInfo(const pat::GenericParticle& cand, const UShort_t& 
 
   // push data and return index
   info.pushData(cand);
-  info.clearTemp();
   return idx;
 };
 
@@ -1960,7 +1951,6 @@ ParticleAnalyzer::fillPFCandidateInfo(const pat::GenericParticle& cand, const US
 
   // push data and return index
   info.pushData(cand);
-  info.clearTemp();
   return idx;
 };
 
@@ -2082,7 +2072,6 @@ ParticleAnalyzer::fillGenParticleInfo(const reco::GenParticleRef& candR, const U
     if (momIdx!=USHRT_MAX) { info.push(idx, "momIdx", momIdx); }
   }
 
-  info.clearTemp();
   // return index
   return idx;
 }

--- a/VertexCompositeAnalyzer/plugins/ParticleAnalyzer.cc
+++ b/VertexCompositeAnalyzer/plugins/ParticleAnalyzer.cc
@@ -462,6 +462,8 @@ private:
     };
 
     // clear
+    void clearTemp() { data_.clear(); }
+
     void clear()
     {
       size_ = 0;
@@ -1253,6 +1255,7 @@ ParticleAnalyzer::fillTriggerObjectInfo(const pat::TriggerObjectStandAlone& obj,
 
   // push data and return index
   info.pushData(obj);
+  info.clearTemp();
   return idx;
 }
 
@@ -1419,6 +1422,7 @@ ParticleAnalyzer::fillRecoParticleInfo(const pat::GenericParticle& cand, const U
     }
   }
 
+  info.clearTemp();
   // return index
   return idx;
 }
@@ -1571,6 +1575,7 @@ ParticleAnalyzer::fillTrackInfo(const pat::GenericParticle& cand, const UShort_t
 
   // push data and return index
   info.pushData(cand);
+  info.clearTemp(); 
   return idx;
 }
 
@@ -1580,11 +1585,12 @@ ParticleAnalyzer::fillSourceInfo(const pat::GenericParticle& cand, const UShort_
 {
   // fill source information
   const auto pdgId = std::abs(cand.pdgId());
-  if      (pdgId<=6 ) { return fillJetInfo(cand, candIdx, force);      }
-  else if (pdgId==11) { return fillElectronInfo(cand, candIdx, force); }
-  else if (pdgId==13) { return fillMuonInfo(cand, candIdx, force);     }
-  else if (pdgId==15) { return fillTauInfo(cand, candIdx, force);      }
-  else if (pdgId==22) { return fillPhotonInfo(cand, candIdx, force);   }
+  if      (pdgId==0 ) { return fillPFCandidateInfo(cand, candIdx, force); }
+  else if (pdgId<=6 ) { return fillJetInfo(cand, candIdx, force);         }
+  else if (pdgId==11) { return fillElectronInfo(cand, candIdx, force);    }
+  else if (pdgId==13) { return fillMuonInfo(cand, candIdx, force);        }
+  else if (pdgId==15) { return fillTauInfo(cand, candIdx, force);         }
+  else if (pdgId==22) { return fillPhotonInfo(cand, candIdx, force);      }
   // if pdgId not matched, use PF candidates
   return fillPFCandidateInfo(cand, candIdx, force);
 }
@@ -1720,6 +1726,7 @@ ParticleAnalyzer::fillMuonInfo(const pat::GenericParticle& cand, const UShort_t&
 
   // push data and return index
   info.pushData(cand);
+  info.clearTemp();
   return idx;
 };
 
@@ -1766,6 +1773,7 @@ ParticleAnalyzer::fillElectronInfo(const pat::GenericParticle& cand, const UShor
 
   // push data and return index
   info.pushData(cand);
+  info.clearTemp();
   return idx;
 };
 
@@ -1823,6 +1831,7 @@ ParticleAnalyzer::fillPhotonInfo(const pat::GenericParticle& cand, const UShort_
 
   // push data and return index
   info.pushData(cand);
+  info.clearTemp();
   return idx;
 };
 
@@ -1882,6 +1891,7 @@ ParticleAnalyzer::fillJetInfo(const pat::GenericParticle& cand, const UShort_t& 
 
   // push data and return index
   info.pushData(cand);
+  info.clearTemp();
   return idx;
 };
 
@@ -1915,6 +1925,7 @@ ParticleAnalyzer::fillTauInfo(const pat::GenericParticle& cand, const UShort_t& 
 
   // push data and return index
   info.pushData(cand);
+  info.clearTemp();
   return idx;
 };
 
@@ -1949,6 +1960,7 @@ ParticleAnalyzer::fillPFCandidateInfo(const pat::GenericParticle& cand, const US
 
   // push data and return index
   info.pushData(cand);
+  info.clearTemp();
   return idx;
 };
 
@@ -2070,6 +2082,7 @@ ParticleAnalyzer::fillGenParticleInfo(const reco::GenParticleRef& candR, const U
     if (momIdx!=USHRT_MAX) { info.push(idx, "momIdx", momIdx); }
   }
 
+  info.clearTemp();
   // return index
   return idx;
 }


### PR DESCRIPTION
I made two changes:
1. In `fillSourceInfo`, the particles with `pdgId` equal to 0 will be passed to `fillJetIfo`. But it should be set to PFCandidate according to the [link](https://github.com/stahlleiton/VertexCompositeAnalysis/blob/ParticleFitter_10_3_X/VertexCompositeProducer/src/ParticleFitter.cc#L172).
2. When users want to retrieve candidate info from track via `trk_candIdx` in `ParticleTree`, they will find the the index vector of each track will have size increased one by one: the new candidate index will append to the old vector, looking like:
   - `trk_candIdx->at(0)` => `{2}`
   - `trk_candIdx->at(1)` => `{2, 13}`
   - `trk_candIdx->at(2)` => `{2, 13, 4}`
   - ...
 This is because `particleInfo_["trk"].["candIdx"]` is modified via `ParticleContainer::push` in `fillRecoInfo`. If the input `cand` cannot be found in the `particleInfo_["trk"]`, then `particleInfo_["trk"].data_` will be modified. And then the values inside `particleInfo_["trk"].data_` will be pushed to `*_VM` and `*_VVM`. However, `particleInfo_["trk"].data_` is not cleared. If next time, a new `cand` not in `particleInfo_["trk"]` is passed into `fillTrackInfo`, its `candIdx` will be appended onto the back of `particleInfo_["trk"].data_["candIdx"]` via `push`, instead of resetting its value. I created a member function called `ParticleContainer::clearTemp` to clear the info in `ParticleContainer::data_`, to solve this issue. Whenever `ParticleContainer::pushData` is called, `clearTemp` should be called to clear info useless info in `data_` since the info in `data_` has been pushed into `*_VM` and `*_VVM`.
3. Similar cases to item 2 also happens in other `fillXXXXInfo` functions.